### PR TITLE
[#67] 알림 설정 페이지 구현

### DIFF
--- a/src/app/(main)/menu/settings/alarm/page.tsx
+++ b/src/app/(main)/menu/settings/alarm/page.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { Bell, Mail } from 'lucide-react'
+import { useState } from 'react'
+
+import { Card } from '@/shared/ui/Card'
+import { Toggle } from '@/shared/ui/Toggle'
+
+export default function AlarmPage() {
+  const [pushEnabled, setPushEnabled] = useState(true)
+  const [emailEnabled, setEmailEnabled] = useState(true)
+
+  return (
+    <div className="space-y-6 pt-2 pb-6">
+      <Card className="p-4">
+        <div className="divide-y divide-border">
+          <div className="flex items-center gap-4 py-4">
+            <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+              <Bell size={20} className="text-primary" />
+            </div>
+            <div className="flex-1">
+              <p className="font-medium text-sm">푸시 알림</p>
+              <p className="text-xs text-muted-foreground">앱 알림을 받습니다</p>
+            </div>
+            <Toggle
+              checked={pushEnabled}
+              onCheckedChange={setPushEnabled}
+              label="푸시 알림"
+            >
+              <Toggle.Track>
+                <Toggle.Thumb />
+              </Toggle.Track>
+            </Toggle>
+          </div>
+
+          <div className="flex items-center gap-4 py-4">
+            <div className="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center">
+              <Mail size={20} className="text-secondary" />
+            </div>
+            <div className="flex-1">
+              <p className="font-medium text-sm">이메일 알림</p>
+              <p className="text-xs text-muted-foreground">이메일로 알림을 받습니다</p>
+            </div>
+            <Toggle
+              checked={emailEnabled}
+              onCheckedChange={setEmailEnabled}
+              label="이메일 알림"
+            >
+              <Toggle.Track>
+                <Toggle.Thumb />
+              </Toggle.Track>
+            </Toggle>
+          </div>
+        </div>
+      </Card>
+
+      <p className="text-center text-xs text-muted-foreground leading-relaxed">
+        알림 설정은 로그인 시 계정에 저장됩니다.
+        <br />
+        비로그인 상태에서는 이 기기에만 적용됩니다.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
### 📋 관련 이슈
Fixes #67 

### 🧩 작업 내용
- 알림 설정 페이지 구현 (`/menu/settings/alarm`)
- 푸시 알림 / 이메일 알림 토글 UI 구현
- 알림 정책서 기반 푸시·이메일 알림 설정 항목 반영
- 비로그인 상태 안내 문구 추가

### ✅ 테스트 결과
- [x] lint
- [x] build
