### PR TITLE
[#85] 대시보드 앱 명칭 다크모드 적용 안되는 현상 수정

### DIFF
--- a/src/app/(main)/(dashboard)/layout.tsx
+++ b/src/app/(main)/(dashboard)/layout.tsx
@@ -67,9 +67,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             </span>
           }
           subtitle={
-            <span className="text-2xl font-bold mt-0.5 text-accent-foreground">
-              {config.subtitle}
-            </span>
+            <span className="text-2xl font-bold mt-0.5 text-(--foreground)">{config.subtitle}</span>
           }
           right={
             config.right && (


### PR DESCRIPTION
### 📋 관련 이슈
Fixes #86

### 🧩 작업 내용
- 대시보드 앱 명칭 다크모드 적용 안되는 현상 수정

### ✅ 테스트 결과
- [x] lint
- [x] build
